### PR TITLE
Add viewport meta for better UI on mobile devices

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <head>
   <title>Encrypt.to | Secure Contact Form</title>
 	<meta http-equiv="Pragma" content="no-cache">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="Send encrypted PGP messages by one click. GPG">
 	<meta name="keywords" content="pgp, openpgp, encryption, encrypt, privacy">
 	<meta name="robots" content="index,follow">


### PR DESCRIPTION
[Viewport instruction][0] will make the browser render UI elements with a natural scale.

[0]: https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag

Before this change:

![no-viewport](https://user-images.githubusercontent.com/1718963/42562607-76fd52aa-84fc-11e8-96cf-16c4f3cac4f1.PNG)

After this change:

![vierport](https://user-images.githubusercontent.com/1718963/42562614-7b8ec4f2-84fc-11e8-9178-1856b856ba24.PNG)
